### PR TITLE
use openssl base64 to be MacOS compatible

### DIFF
--- a/shell-helper.sh
+++ b/shell-helper.sh
@@ -12,7 +12,7 @@ function getStageSecretsBucket(){
   secretspath="/terraform-secrets"
   current_date=$(date +'%a, %d %b %Y %H:%M:%S %z')
   request_string="GET\n\n\n${current_date}\n/${BUCKET_NAME}${secretspath}"
-  signed_reqest=$(echo -en "${request_string}" | openssl sha1 -hmac "${AWS_SECRET_ACCESS_KEY}" -binary | base64)
+  signed_reqest=$(echo -en "${request_string}" | openssl sha1 -hmac "${AWS_SECRET_ACCESS_KEY}" -binary | openssl base64)
   curl -s -H "Host: ${BUCKET_NAME}.obs.eu-de.otc.t-systems.com" \
        -H "Date: ${current_date}" \
        -H "Authorization: AWS ${AWS_ACCESS_KEY_ID}:${signed_reqest}" \


### PR DESCRIPTION
Hi there,

first of all, thanks a lot for all the effort put into this blueprint.

I followed your readme instructions and noticed that the shell-helper function [getStageSecretsBucket](https://github.com/iits-consulting/otc-terraform-template/blob/main/shell-helper.sh#L4) seemed broken.

I am running it on MacOS 12.4 and tried both, with bash (GNU bash, version 3.2.57(1)-release arm64-apple-darwin21) and zsh (v5.8.1)

I debugged the function setting `set -v -x -e` which shows this output

```
bash-3.2$ 
bash-3.2$ source set-env.sh 
bash-3.2$ source shell-helper.sh 
bash-3.2$ set -v -x -e
bash-3.2$ getStageSecretsBucket 
getStageSecretsBucket 
+ getStageSecretsBucket
+ [[ -z eu-de ]]
+ PROJECT=eu-de
+ CONTEXT=helloworldapp
+ BUCKET_NAME=eu-de-helloworldapp-dev-stage-secrets
+ secretspath=/terraform-secrets
date +'%a, %d %b %Y %H:%M:%S %z'
++ date '+%a, %d %b %Y %H:%M:%S %z'
+ current_date='Wed, 25 May 2022 11:40:08 +0200'
+ request_string='GET\n\n\nWed, 25 May 2022 11:40:08 +0200\n/eu-de-helloworldapp-dev-stage-secrets/terraform-secrets'
echo -en "${request_string}" | openssl sha1 -hmac "${AWS_SECRET_ACCESS_KEY}" -binary | base64
++ echo -en 'GET\n\n\nWed, 25 May 2022 11:40:08 +0200\n/eu-de-helloworldapp-dev-stage-secrets/terraform-secrets'
++ openssl sha1 -hmac xxxxxxxxxxxxxxxxxxxxxxxx -binary
++ base64
+ signed_reqest=$'vX9RDcs7939iJQCbFzZY34WzbYM=\r'
+ curl -s -H 'Host: eu-de-helloworldapp-dev-stage-secrets.obs.eu-de.otc.t-systems.com' -H 'Date: Wed, 25 May 2022 11:40:08 +0200' -H 'Authorization: ' https://eu-de-helloworldapp-dev-stage-secrets.obs.eu-de.otc.t-systems.com/terraform-secrets
<h1>Bad Message 400</h1><pre>reason: Bad EOL</pre>
bash-3.2$
```

I found out that the MacOS version of `base64` seems to add a linebreak and does not work exactly link on linux.
I was able to fix the issue on my MacOS system by using `openssl base64` instead of `base64`. 
**This preserves the functionality on linux and makes sure this helper runs on MacOS too**.

Hope that is useful 

All the best 
Karsten